### PR TITLE
Geskippten Deadline-Test entfernen

### DIFF
--- a/tests/model/test_turn.py
+++ b/tests/model/test_turn.py
@@ -31,13 +31,6 @@ class TurnTest(unittest.TestCase):
 
         with self.assertRaises(ex.MultipleActionByPlayerError): self.sut.action(self.player1)
 
-    @unittest.skip
-    def test_deadlineException(self):
-        date = datetime.now() - timedelta(0, 180)
-        self.sut = Turn(self.players, date)
-
-        with self.assertRaises(ex.DeadLineExceededException): self.sut.action(self.player1)
-
     def test_new_turn_should_be_initialized(self):
         old_turn_ctr = self.sut.turn_ctr
         self.sut.action(self.player1)


### PR DESCRIPTION
Test der Geskipped wird, gegen den wir uns entscheiden hatten, entfernen, weil der nervt bloß und ist auch in 1 Minute bei Bedarf neu geschrieben :D