### PR TITLE
Performance optimierung pathfindingai

### DIFF
--- a/chillow/ai/pathfinding_ai.py
+++ b/chillow/ai/pathfinding_ai.py
@@ -62,7 +62,7 @@ class PathfindingAI(ArtificialIntelligence):
                 path, runs = path_finder.find_path(start, end, grid)
                 if len(path) > 0:
                     current_possible_paths += 1
-                if current_possible_paths + length_free_cells - i <= best_action[1]:  # can't be better
+                if current_possible_paths + length_free_cells - i <= best_action[1]:  # can't get better
                     break
             if len(best_action) == 0 or best_action[1] < current_possible_paths:
                 best_action = (action, current_possible_paths)


### PR DESCRIPTION
Zum einen sucht die AI nicht mehr weiter, wenn alle Pfade durch eine AKtion bereits erreicht werden konnten, da keine Aktion besser sein kann
und zum anderen bricht die KI das Ausführen des Pathfinding-Algorithmus für weitere Punkte ab, wenn diese Aktion nicht mehr besser werden kann als die bisher beste AKtion