### PR TITLE
Unnötigen Durchlauf der Pathfinding_AI vermeiden und korrekte super-Methode aufrufen

### DIFF
--- a/chillow/ai/artificial_intelligence.py
+++ b/chillow/ai/artificial_intelligence.py
@@ -18,7 +18,7 @@ class ArtificialIntelligence(metaclass=ABCMeta):
 
     @abstractmethod
     def create_next_action(self, game: Game) -> Action:
-        self.turn_ctr += 1
+        raise NotImplementedError
 
     def find_surviving_actions(self, game_service: GameService) -> List[Action]:
         result: List[Action] = []

--- a/chillow/ai/not_killing_itself_ai.py
+++ b/chillow/ai/not_killing_itself_ai.py
@@ -25,7 +25,7 @@ class NotKillingItselfAI(ArtificialIntelligence):
         self.max_worse_distance = max_worse_distance
 
     def create_next_action(self, game: Game) -> Action:
-        super().create_next_action(game)
+        self.turn_ctr += 1
 
         game_service = GameService(game)
         game_service.turn.turn_ctr = self.turn_ctr

--- a/chillow/ai/pathfinding_ai.py
+++ b/chillow/ai/pathfinding_ai.py
@@ -21,7 +21,7 @@ class PathfindingAI(ArtificialIntelligence):
         self.count_paths_to_check = count_paths_to_check
 
     def create_next_action(self, game: Game) -> Action:
-        super().create_next_action(game)
+        self.turn_ctr += 1
 
         game_service = GameService(game)
         game_service.turn.turn_ctr = self.turn_ctr

--- a/chillow/ai/pathfinding_search_tree_ai.py
+++ b/chillow/ai/pathfinding_search_tree_ai.py
@@ -1,4 +1,3 @@
-from chillow.ai.artificial_intelligence import ArtificialIntelligence
 from chillow.ai.pathfinding_ai import PathfindingAI
 from chillow.ai.search_tree_node import SearchTreeRoot
 from chillow.model.action import Action
@@ -13,7 +12,7 @@ class PathfindingSearchTreeAI(PathfindingAI):
         self.__depth = depth
 
     def create_next_action(self, game: Game) -> Action:
-        ArtificialIntelligence.create_next_action(self, game)
+        self.turn_ctr += 1
         root = SearchTreeRoot(game.copy())
         combinations = Action.get_combinations(len(game.get_other_players(self.player)))
 

--- a/chillow/ai/random_ai.py
+++ b/chillow/ai/random_ai.py
@@ -11,7 +11,7 @@ from chillow.model.game import Game
 class RandomAI(ArtificialIntelligence):
 
     def create_next_action(self, game: Game) -> Action:
-        super().create_next_action(game)
+        self.turn_ctr += 1
         return Action.get_random_action()
 
 

--- a/chillow/ai/search_tree_ai.py
+++ b/chillow/ai/search_tree_ai.py
@@ -13,7 +13,7 @@ class SearchTreeAI(ArtificialIntelligence):
         self.__randomize = randomize
 
     def create_next_action(self, game: Game) -> Action:
-        super().create_next_action(game)
+        self.turn_ctr += 1
         root = SearchTreeRoot(game.copy())
         combinations = Action.get_combinations(len(game.get_other_players(self.player)))
 


### PR DESCRIPTION
Unnötigen Durchlauf der Pathfinding_AI vermeiden und korrekte Super-Klasse aufrufen.

Es wurde jedes mal der gesamte Pathfinding-Algorithmus einmal durchlaufen ohne das Resultat zu verwenden.
